### PR TITLE
Reinstate bounds for warning suppression to 3rd party headers.

### DIFF
--- a/drophash/stdafx.h
+++ b/drophash/stdafx.h
@@ -9,7 +9,11 @@
 // #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
 // Windows Header Files:
 #pragma warning (push, 1)
-#pragma warning (disable : 4514 5039 4668 4996 26814 4548 4355 4917 4702 26400 4987 4820 4365 4623 4625 4626 5026 5027 4571 4774 26412 26461 26426 26432 26447 26472 26446 26473 26440 26429 26496 26472 26482 26486 26487 26434)
+#pragma warning(disable : 4514 5039 4668 4996 26814 4548 4355 4917 4702)
+#pragma warning(disable : 26400 4987 4820 4365 4623 4625 4626 5026 5027)
+#pragma warning(disable : 4571 4774 26412 26461 26426 26432 26447 26472)
+#pragma warning(disable : 26446 26473 26440 26429 26496 26482 26486 26487 26434)
+
 #include <gsl/gsl>
 
 #include <windows.h>

--- a/drophash/stdafx.h
+++ b/drophash/stdafx.h
@@ -4,15 +4,14 @@
 //
 
 #pragma once
-#pragma warning (disable : 4514 4710 4711) // inlining
 #pragma warning (disable: 5045) // TODO Spectre
 
 // #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
 // Windows Header Files:
 #pragma warning (push, 1)
-#pragma warning (disable : 5039 4668 4996 26814 4548 4355 4917 4702 26400 4987 4820 4365 4623 4625 4626 5026 5027 4571 4774 26412 26461 26426 26432 26447 26472 26446 26473 26440 26429 26496 26472 26482 26486 26487 26434)
+#pragma warning (disable : 4514 5039 4668 4996 26814 4548 4355 4917 4702 26400 4987 4820 4365 4623 4625 4626 5026 5027 4571 4774 26412 26461 26426 26432 26447 26472 26446 26473 26440 26429 26496 26472 26482 26486 26487 26434)
 #include <gsl/gsl>
- 
+
 #include <windows.h>
 #include <Shlobj.h>
 #include <Strsafe.h>
@@ -30,4 +29,4 @@
 #include <span>
 
 #include "Resource.h"
-
+#pragma warning (pop)


### PR DESCRIPTION
adjusting the stdafx.h pragma statements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved organization of warning settings and minor whitespace adjustments for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->